### PR TITLE
Improved Ontologies page and other small changes

### DIFF
--- a/pages/10_🌍_Global_Configuration.py
+++ b/pages/10_🌍_Global_Configuration.py
@@ -206,7 +206,6 @@ def unbind_all_namespaces():
     # reset fields_____________________________
     st.session_state["key_unbind_multiselect"] = []
 
-
 #TAB3
 def save_progress():
     # name of temporary file_____________
@@ -272,7 +271,7 @@ with tab1:
     st.write("")
     st.write("")
 
-    # PURPLE HEADER: CREATE NEW MAPPING-----------------------------------------
+    # PURPLE HEADING: CREATE NEW MAPPING----------------------------------------
     col1,col2,col3 = st.columns([2,0.5, 1])
     with col1:
         st.markdown("""<div class="purple-heading">
@@ -346,7 +345,7 @@ with tab1:
         st.write("______")
 
 
-    # PURPLE HEADER- IMPORT EXISTING MAPPING------------------------------------
+    # PURPLE HEADING- IMPORT EXISTING MAPPING-----------------------------------
     with col1:
         st.markdown("""<div class="purple-heading">
                 📁 Import Existing Mapping
@@ -554,7 +553,7 @@ with tab1:
         time.sleep(utils.get_success_message_time())
         st.rerun()
 
-    # MAPPING INFORMATION BOX---------------------------------------------------
+    # RIGHT COLUMN: MAPPING INFORMATION BOX-------------------------------------
     with col3:
         if st.session_state["g_label"]:
 
@@ -604,7 +603,7 @@ with tab1:
             </div>
             """, unsafe_allow_html=True)
 
-    # OPTION - Retrieve cached mapping------------------------------------------
+    # RIGHT COLUMN OPTION: Retrieve cached mapping------------------------------
     # Only shows if not working with a mapping
     if not st.session_state["g_label"]:
         pkl_cache_filename = next((f for f in os.listdir() if f.endswith("_cache__.pkl")), None)  # fallback if no match is found
@@ -627,7 +626,7 @@ with tab1:
                     st.write("")
                     st.button("Load", key="key_retrieve_cached_mapping_button", on_click=retrieve_cached_mapping)
 
-    # OPTION - Change the mapping label-----------------------------------------
+    # RIGHT COLUMN OPTION: Change the mapping label-----------------------------
     # Only shows if working with a mapping
     if st.session_state["g_label"]:
 
@@ -647,7 +646,7 @@ with tab1:
                             {g_label_candidate}</b> (currently <b>{st.session_state["g_label"]}</b>).
                         </span></div>""", unsafe_allow_html=True)
 
-    # OPTION - Full reset-------------------------------------------------------
+    # RIGHT COLUMN OPTION: Full reset-------------------------------------------
     # Only shows if there is a mapping, ontology or data source
     if (st.session_state["g_label"] or st.session_state["db_connections_dict"]
         or st.session_state["ds_files_dict"] or st.session_state["g_ontology_components_dict"]):
@@ -685,7 +684,7 @@ with tab2:
 
         col1,col2 = st.columns([2,1.5])
 
-        # Display last added namespaces in dataframe (if any)
+        # RIGHT COLUMN: ADDED NS INFO-------------------------------------------
         mapping_ns_dict = utils.get_g_ns_dict(st.session_state["g_mapping"])
         used_mapping_ns_dict = utils.get_used_g_ns_dict(st.session_state["g_mapping"])
 
@@ -724,7 +723,7 @@ with tab2:
                 st.dataframe(mapping_ns_df, hide_index=True)
 
 
-        # PURPLE HEADING - ADD NEW NAMESPACE------------------------------------
+        # PURPLE HEADING: ADD NEW NAMESPACE-------------------------------------
         with col1:
             st.markdown("""<div class="purple-heading">
                     🆕 Add New Namespace
@@ -1115,7 +1114,7 @@ with tab2:
                 time.sleep(utils.get_success_message_time())
                 st.rerun()
 
-        # PURPLE HEADING - UNBIND NAMESPACE-------------------------------------
+        # PURPLE HEADING: UNBIND NAMESPACE--------------------------------------
         # Only shows if there are bound namespaces
         if list_to_choose:
             with col1:
@@ -1203,7 +1202,7 @@ with tab3:
         with col2:
             col2a,col2b = st.columns([1,2])
 
-        # OPTION - SAVE PROGRESS------------------------------------------------
+        # RIGHT COLUMN OPTION: SAVE PROGRESS------------------------------------
         with col2b:
             st.write("")
             save_progress_checkbox = st.checkbox(
@@ -1235,7 +1234,7 @@ with tab3:
             st.rerun()
 
 
-        # PURPLE HEADING - EXPORT MAPPING---------------------------------------
+        # PURPLE HEADING: EXPORT MAPPING----------------------------------------
         with col1:
             st.markdown("""<div class="purple-heading">
                     📤 Export mapping
@@ -1308,7 +1307,7 @@ with tab3:
                             {inner_html}
                         </div>""", unsafe_allow_html=True)
 
-        # PURPLE HEADING - SAVE SESSION-----------------------------------------
+        # PURPLE HEADING: SAVE SESSION------------------------------------------
         with col1:
             st.write("________")
             st.markdown("""<div class="purple-heading">
@@ -1425,7 +1424,7 @@ with tab4:
     with col2:
         col2a,col2b = st.columns([1,2])
 
-    # PURPLE HEADING - STYLE CONFIGURATION--------------------------------------
+    # PURPLE HEADING: STYLE CONFIGURATION---------------------------------------
     with col1:
         st.markdown("""<div class="purple-heading">
                 🎨 Style Configuration

--- a/pages/10_🌍_Global_Configuration.py
+++ b/pages/10_🌍_Global_Configuration.py
@@ -130,6 +130,8 @@ def change_g_label():
 def full_reset():
     # full reset___________________________
     utils.full_reset()
+    #store information___________________________
+    st.session_state["everything_reseted_ok_flag"] = True
     # reset fields___________________________
     st.session_state["key_full_reset_checkbox"] = False
 
@@ -519,7 +521,9 @@ with tab1:
             else:
                 st.button("Retrieve", key="key_retrieve_session_button_2", on_click=retrieve_session)
 
-    # SUCCESS MESSAGES for retrieve cached mapping and change label-------------
+    # SUCCESS MESSAGES----------------------------------------------------------
+    # for retrieve cached mapping, change label and full reset
+
     if st.session_state["cached_mapping_retrieved_ok_flag"]:
         with col3:
             st.write("")
@@ -537,6 +541,16 @@ with tab1:
                 ✅ Mapping was renamed to <b style="color:#F63366;">{st.session_state["g_label"]}</b>!
             </div>""", unsafe_allow_html=True)
         st.session_state["g_label_changed_ok_flag"] = False
+        time.sleep(utils.get_success_message_time())
+        st.rerun()
+
+    if st.session_state["everything_reseted_ok_flag"]:
+        with col3:
+            st.write("")
+            st.markdown(f"""<div class="success-message-flag">
+                ✅ <b>Clean slate:</b> Everything has been <b style="color:#F63366;">reset</b>!
+            </div>""", unsafe_allow_html=True)
+        st.session_state["everything_reseted_ok_flag"] = False
         time.sleep(utils.get_success_message_time())
         st.rerun()
 
@@ -1211,9 +1225,7 @@ with tab3:
 
 
         if st.session_state["progress_saved_ok_flag"]:
-            with col1:
-                col1a, col1b = st.columns([2,1])
-            with col1a:
+            with col2b:
                 st.write("")
                 st.markdown(f"""<div class="success-message-flag">
                     ✅ Current state of mapping <b style="color:#F63366;">{st.session_state["g_label"]}</b> has been cached!

--- a/pages/20_🧩_Ontologies.py
+++ b/pages/20_🧩_Ontologies.py
@@ -468,10 +468,10 @@ with tab2:
     with col2b:
         utils.get_corner_status_message_mapping()
 
-    #PURPLE HEADING - SEARCH ONTOLOGY
+    #PURPLE HEADING - EXPLORE ONTOLOGY
     with col1:
         st.markdown("""<div class="purple-heading">
-                🔍 Search Ontology
+                🔍 Explore Ontology
             </div>""", unsafe_allow_html=True)
         st.write("")
 
@@ -1049,10 +1049,9 @@ with tab3:
         with col1:
             col1a, col1b = st.columns([2,1])
         with col1a:
-            format_options_dict = {"🐢 turtle": "turtle", "3️⃣ ntriples": "nt",
-                "📐 trig": "trig"}
+            format_options_dict = {"🐢 turtle": "turtle", "3️⃣ ntriples": "nt"}
             preview_format_display = st.radio("🖱️ Select format:*", format_options_dict,
-                horizontal=True, key="key_export_format_selectbox")
+                label_visibility="collapsed", horizontal=True, key="key_export_format_selectbox")
             preview_format = format_options_dict[preview_format_display]
 
         if len(st.session_state["g_ontology_components_dict"]) > 1:

--- a/pages/20_🧩_Ontologies.py
+++ b/pages/20_🧩_Ontologies.py
@@ -58,6 +58,7 @@ def load_ontology_from_file():
     # reset fields___________________________
     st.session_state["key_ontology_uploader"] = str(uuid.uuid4())
     st.session_state["ontology_file"] = None
+    st.session_state["key_import_ontology_selected_option"] = "🌐 URL"
 
 def extend_ontology_from_link():
     # load ontology
@@ -103,7 +104,7 @@ def extend_ontology_from_file():
     # reset fields___________________________
     st.session_state["key_ontology_uploader"] = str(uuid.uuid4())
     st.session_state["ontology_file"] = None
-    st.session_state["key_extend_ontology_selected_option"] = "📁 File"
+    st.session_state["key_import_ontology_selected_option"] = "🌐 URL"
 
 def reduce_ontology():
     #store information___________________________
@@ -128,31 +129,7 @@ with tab1:
 
     col1, col2 = st.columns([2,1.5])
 
-    if st.session_state["g_ontology_loaded_ok_flag"]:
-        with col1:
-            col1a, col1b = st.columns([2,1])
-        with col1a:
-            st.write("")
-            st.markdown(f"""<div class="success-message-flag">
-                ✅ The <b>ontology</b> has been imported!
-            </div>""", unsafe_allow_html=True)
-        st.session_state["g_ontology_loaded_ok_flag"] = False
-        time.sleep(utils.get_success_message_time())
-        st.rerun()
-
-    if st.session_state["g_ontology_reduced_ok_flag"]:
-        with col1:
-            col1a, col1b = st.columns([2,1])
-        with col1a:
-            st.write("")
-            st.markdown(f"""<div class="success-message-flag">
-                ✅ The <b>ontology/ies</b> have been removed!
-            </div>""", unsafe_allow_html=True)
-        st.session_state["g_ontology_reduced_ok_flag"] = False
-        time.sleep(utils.get_success_message_time())
-        st.rerun()
-
-
+    # RIGHT COLUMN: ONTOLOGY INFO-----------------------------------------------
     with col2:
         col2a,col2b = st.columns([1,2])
         with col2b:
@@ -169,220 +146,176 @@ with tab1:
         <small> Some <b>patience</b> may be required.</small>
             </div>""", unsafe_allow_html=True)
 
-    #LOAD ONTOLOGY FROM URL___________________________________
-    if not st.session_state["g_ontology"]:   #no ontology is loaded yet
+    # SUCCESS MESSAGES----------------------------------------------------------
+    if st.session_state["g_ontology_reduced_ok_flag"]:
         with col1:
+            col1a, col1b = st.columns([2,1])
+        with col1a:
             st.write("")
-            st.write("")
-            st.markdown("""<div class="purple-heading">
-                    ➕ Add New Ontology
-                </div>""", unsafe_allow_html=True)
-            st.write("")
+            st.markdown(f"""<div class="success-message-flag">
+                ✅ The <b>ontology/ies</b> have been removed!
+            </div>""", unsafe_allow_html=True)
+        st.session_state["g_ontology_reduced_ok_flag"] = False
+        time.sleep(utils.get_success_message_time())
+        st.rerun()
 
+    #PURPLE HEADING: ADD NEW ONTOLOGY-------------------------------------------
+    with col1:
+        st.write("")
+        st.write("")
+        st.markdown("""<div class="purple-heading">
+                ➕ Add New Ontology
+            </div>""", unsafe_allow_html=True)
+        st.write("")
+
+    if st.session_state["g_ontology_loaded_ok_flag"]:
         with col1:
-            col1a,col1b = st.columns([2,1])
+            col1a, col1b = st.columns([2,1])
+        with col1a:
+            st.write("")
+            st.markdown(f"""<div class="success-message-flag">
+                ✅ The <b>ontology</b> has been imported!
+            </div>""", unsafe_allow_html=True)
+        st.session_state["g_ontology_loaded_ok_flag"] = False
+        time.sleep(utils.get_success_message_time())
+        st.rerun()
 
-        with col1b:
-            import_ontology_selected_option = st.radio("🖱️ Import ontology from:*", ["🌐 URL", "📁 File"],
-                label_visibility="hidden", horizontal=True, key="key_import_ontology_selected_option")
+    with col1:
+        col1a,col1b = st.columns([2,1])
 
-        if import_ontology_selected_option == "🌐 URL":
+    with col1b:
+        import_ontology_selected_option = st.radio("🖱️ Import ontology from:*", ["🌐 URL", "📁 File"],
+            label_visibility="hidden", horizontal=True, key="key_import_ontology_selected_option")
 
-            with col1a:
-                ontology_link = st.text_input("🌐 Enter link to ontology:*", key="key_ontology_link")
-            st.session_state["ontology_link"] = ontology_link if ontology_link else ""
+    if import_ontology_selected_option == "🌐 URL":
 
-            if ontology_link:
+        with col1a:
+            ontology_link = st.text_input("⌨️ Enter link to ontology:*", key="key_ontology_link")
+        st.session_state["ontology_link"] = ontology_link if ontology_link else ""
 
-                #http://purl.org/ontology/bibo/
-                #http://xmlns.com/foaf/0.1/
+        if ontology_link:
 
-                g_candidate, fmt_candidate = utils.parse_ontology(st.session_state["ontology_link"])
-                st.session_state["g_ontology_from_link_candidate"] = g_candidate
-                st.session_state["g_ontology_from_link_candidate_fmt"] = fmt_candidate
-                st.session_state["g_ontology_from_link_candidate_label"] = utils.get_ontology_human_readable_name(st.session_state["g_ontology_from_link_candidate"], source_link=st.session_state["ontology_link"])
+            g_candidate, fmt_candidate = utils.parse_ontology(st.session_state["ontology_link"])
+            st.session_state["g_ontology_from_link_candidate"] = g_candidate
+            st.session_state["g_ontology_from_link_candidate_fmt"] = fmt_candidate
+            st.session_state["g_ontology_from_link_candidate_label"] = utils.get_ontology_human_readable_name(st.session_state["g_ontology_from_link_candidate"], source_link=st.session_state["ontology_link"])
 
-                if not utils.is_valid_ontology(g_candidate):
-                    with col1a:
-                        st.markdown(f"""<div class="error-message">
-                            ❌ URL <b>does not</b> link to a valid ontology.
+            if not utils.is_valid_ontology(g_candidate):
+                with col1a:
+                    st.markdown(f"""<div class="error-message">
+                        ❌ URL <b>does not</b> link to a valid ontology.
+                    </div>""", unsafe_allow_html=True)
+                    st.write("")
+
+            else:
+                with col1:
+                    col1a, col1b = st.columns(2)
+
+                with col1b:
+                    st.markdown(f"""<div class="success-message">
+                            ✔️ <b>Valid ontology:</b> <b style="color:#F63366;">
+                            {st.session_state["g_ontology_from_link_candidate_label"]}</b>
+                            <small>(parsed successfully with format
+                            <b>{st.session_state["g_ontology_from_link_candidate_fmt"]}</b>).</small>
                         </div>""", unsafe_allow_html=True)
-                        st.write("")
 
-                else:
-                    with col1:
-                        col1a, col1b = st.columns(2)
+                ontology_ns_dict = utils.get_g_ns_dict(st.session_state["g_ontology_from_link_candidate"])
+                mapping_ns_dict = utils.get_g_ns_dict(st.session_state["g_mapping"])
+                already_used_prefix_list = []
+                already_bound_ns_list = []
+                for pr, ns in ontology_ns_dict.items():
+                    if ns in mapping_ns_dict.values() and (pr not in mapping_ns_dict or mapping_ns_dict[pr] != ns):
+                        already_bound_ns_list.append(ns)
+                    elif pr in mapping_ns_dict and str(ns) != mapping_ns_dict[pr]:
+                        already_used_prefix_list.append(pr)
 
-                    with col1b:
-                        st.markdown(f"""<div class="success-message">
-                                ✔️ <b>Valid ontology:</b> <b style="color:#F63366;">
-                                {st.session_state["g_ontology_from_link_candidate_label"]}</b>
-                                <small>(parsed successfully with format
-                                <b>{st.session_state["g_ontology_from_link_candidate_fmt"]}</b>).</small>
-                            </div>""", unsafe_allow_html=True)
+                if already_used_prefix_list and already_bound_ns_list:
+                    with col1a:
+                        st.markdown(f"""<div class="warning-message">
+                            ⚠️ <small><b>Some prefixes ({len(already_used_prefix_list)}) are already in use</b>
+                            (or reserved) and will be auto-renamed.
+                            <b>Some namespaces ({len(already_bound_ns_list)}) are already bound</b>
+                            (or reserved) to other prefixes and will be ignored.</small>
+                        </div>""", unsafe_allow_html=True)
+                elif already_used_prefix_list:
+                    with col1a:
+                        st.markdown(f"""<div class="warning-message">
+                            ⚠️ <b>Some prefixes ({len(already_used_prefix_list)}) are already in use</b>
+                            <small>(or reserved) and will be auto-renamed with a numeric suffix.</small><br>
+                        </div>""", unsafe_allow_html=True)
+                elif already_bound_ns_list:
+                    with col1a:
+                        st.markdown(f"""<div class="warning-message">
+                            <b>Some namespaces ({len(already_bound_ns_list)}) are already bound</b>
+                            <small>to other prefixes (or reserved) and will be ignored.</small>
+                        </div>""", unsafe_allow_html=True)
 
-                    ontology_ns_dict = utils.get_g_ns_dict(st.session_state["g_ontology_from_link_candidate"])
-                    mapping_ns_dict = utils.get_g_ns_dict(st.session_state["g_mapping"])
-                    already_used_prefix_list = []
-                    already_bound_ns_list = []
-                    for pr, ns in ontology_ns_dict.items():
-                        if ns in mapping_ns_dict.values() and (pr not in mapping_ns_dict or mapping_ns_dict[pr] != ns):
-                            already_bound_ns_list.append(ns)
-                        elif pr in mapping_ns_dict and str(ns) != mapping_ns_dict[pr]:
-                            already_used_prefix_list.append(pr)
-
-                    if already_used_prefix_list and already_bound_ns_list:
-                        with col1a:
-                            st.markdown(f"""<div class="warning-message">
-                                ⚠️ <small><b>Some prefixes ({len(already_used_prefix_list)}) are already in use</b>
-                                (or reserved) and will be auto-renamed.
-                                <b>Some namespaces ({len(already_bound_ns_list)}) are already bound</b>
-                                (or reserved) to other prefixes and will be ignored.</small>
-                            </div>""", unsafe_allow_html=True)
-                    elif already_used_prefix_list:
-                        with col1a:
-                            st.markdown(f"""<div class="warning-message">
-                                ⚠️ <b>Some prefixes ({len(already_used_prefix_list)}) are already in use</b>
-                                <small>(or reserved) and will be auto-renamed with a numeric suffix.</small><br>
-                            </div>""", unsafe_allow_html=True)
-                    elif already_bound_ns_list:
-                        with col1a:
-                            st.markdown(f"""<div class="warning-message">
-                                <b>Some namespaces ({len(already_bound_ns_list)}) are already bound</b>
-                                <small>to other prefixes (or reserved) and will be ignored.</small>
-                            </div>""", unsafe_allow_html=True)
-
-
-
-
+                if not st.session_state["g_ontology"]:   #no ontology imported yet
                     with col1a:
                         st.button("Add", key="key_load_ontology_from_link_button", on_click=load_ontology_from_link)
 
-        elif import_ontology_selected_option == "📁 File":
+                else:  # an ontology is already imported
 
-            ontology_extension_dict = utils.get_g_ontology_file_formats_dict()   #ontology allowed formats
-            ontology_format_list = list(ontology_extension_dict)
-
-            with col1a:
-                st.session_state["ontology_file"] = st.file_uploader(f"""🖱️
-                    Upload ontology file:*""", type=ontology_format_list, key=st.session_state["key_ontology_uploader"])
-
-            if st.session_state["ontology_file"]:
-
-                g_candidate, fmt_candidate = utils.parse_ontology(st.session_state["ontology_file"])
-                st.session_state["g_ontology_from_file_candidate"] = g_candidate
-                st.session_state["g_ontology_from_file_candidate_fmt"] = fmt_candidate
-                st.session_state["g_ontology_from_file_candidate_label"] = utils.get_ontology_human_readable_name(st.session_state["g_ontology_from_file_candidate"], source_file=st.session_state["ontology_file"])
-
-
-                if not utils.is_valid_ontology(g_candidate):
-                    with col1b:
-                        st.markdown(f"""<div class="error-message">
-                            ❌ File <b>does not</b> contain a valid ontology.
-                        </div>""", unsafe_allow_html=True)
-                        st.write("")
-
-                else:
-                    with col1b:
-                        st.markdown(f"""<div class="success-message">
-                                ✔️ <b>Valid ontology:</b> <b style="color:#F63366;">
-                                {st.session_state["g_ontology_from_file_candidate_label"]}</b>
-                                <small>(parsed successfully with format
-                                <b>{st.session_state["g_ontology_from_file_candidate_fmt"]}</b>).</small>
-                            </div>""", unsafe_allow_html=True)
-
-                    with col1a:
-                        st.button("Add", key="key_load_ontology_from_file_button", on_click=load_ontology_from_file)
-
-
-    #EXTEND ONTOLOGY___________________________________
-    if st.session_state["g_ontology"]:   #ontology loaded
-        with col1:
-            st.write("")
-            st.write("")
-            st.markdown("""<div class="purple-heading">
-                    ➕ Add New Ontology
-                </div>""", unsafe_allow_html=True)
-            st.write("")
-
-        with col1:
-            col1a,col1b = st.columns([2,1])
-        with col1b:
-            extend_ontology_selected_option = st.radio("🖱️ Import ontology from:*", ["🌐 URL", "📁 File"],
-                label_visibility="hidden", horizontal=True, key="key_extend_ontology_selected_option")
-
-        if extend_ontology_selected_option == "🌐 URL":
-            with col1a:
-                ontology_link = st.text_input("⌨️ Enter link to ontology:*", key="key_ontology_link")
-            st.session_state["ontology_link"] = ontology_link if ontology_link else ""
-
-            if ontology_link:
-
-                g_candidate, fmt_candidate = utils.parse_ontology(st.session_state["ontology_link"])
-                st.session_state["g_ontology_from_link_candidate"] = g_candidate
-                st.session_state["g_ontology_from_link_candidate_fmt"] = fmt_candidate
-                st.session_state["g_ontology_from_link_candidate_label"] = utils.get_ontology_human_readable_name(st.session_state["g_ontology_from_link_candidate"], source_link=st.session_state["ontology_link"])
-
-                if not utils.is_valid_ontology(g_candidate):
-                    with col1a:
-                        st.markdown(f"""<div class="error-message">
-                            ❌ URL <b>does not</b> link to a valid ontology.
-                        </div>""", unsafe_allow_html=True)
-
-                elif st.session_state["g_ontology_from_link_candidate_label"] in st.session_state["g_ontology_components_dict"]:
-                    with col1a:
-                        st.markdown(f"""<div class="error-message">
-                                ❌ The ontology <b>
-                                {st.session_state["g_ontology_from_link_candidate_label"]}</b>
-                                has already been imported.
-                            </div>""", unsafe_allow_html=True)
-
-                else:
-                    with col1:
-                        col1a, col1b, col1c = st.columns([1,1.8,1.8])
-                    with col1a:
-                        st.button("Add", key="key_extend_ontology_from_link_button", on_click=extend_ontology_from_link)
-                    with col1c:
-                        st.markdown(f"""<div class="success-message">
-                                ✔️ <b>Valid ontology:</b> <b style="color:#F63366;">
-                                {st.session_state["g_ontology_from_link_candidate_label"]}</b>
-                                <small>(parsed successfully with format
-                                <b>{st.session_state["g_ontology_from_link_candidate_fmt"]}</b>).</small>
-                            </div>""", unsafe_allow_html=True)
-
-                    if utils.check_ontology_overlap(st.session_state["g_ontology_from_link_candidate"], st.session_state["g_ontology"]):
-                        with col1b:
-                            st.markdown(f"""<div class="warning-message">
-                                    ⚠️ <b>Ontologies overlap</b>. <small>Check them
-                                    externally to make sure they are aligned and compatible.</small>
+                    if st.session_state["g_ontology_from_link_candidate_label"] in st.session_state["g_ontology_components_dict"]:
+                        with col1a:
+                            st.markdown(f"""<div class="error-message">
+                                    ❌ The ontology <b>
+                                    {st.session_state["g_ontology_from_link_candidate_label"]}</b>
+                                    has already been imported.
                                 </div>""", unsafe_allow_html=True)
+                    else:
+                        with col1a:
+                            st.button("Add", key="key_extend_ontology_from_link_button", on_click=extend_ontology_from_link)
+
+                        if utils.check_ontology_overlap(st.session_state["g_ontology_from_link_candidate"], st.session_state["g_ontology"]):
+                            with col1b:
+                                st.markdown(f"""<div class="warning-message">
+                                        ⚠️ <b>Ontologies overlap</b>. <small>Check them
+                                        externally to make sure they are aligned and compatible.</small>
+                                    </div>""", unsafe_allow_html=True)
 
 
+    elif import_ontology_selected_option == "📁 File":
 
-        if extend_ontology_selected_option == "📁 File":
+        ontology_extension_dict = utils.get_g_ontology_file_formats_dict()   #ontology allowed formats
+        ontology_format_list = list(ontology_extension_dict)
 
-            ontology_extension_dict = utils.get_g_ontology_file_formats_dict()   #ontology allowed formats
-            ontology_format_list = list(ontology_extension_dict)
+        with col1a:
+            st.session_state["ontology_file"] = st.file_uploader(f"""🖱️
+                Upload ontology file:*""", type=ontology_format_list, key=st.session_state["key_ontology_uploader"])
 
-            with col1a:
-                st.session_state["ontology_file"] = st.file_uploader(f"""🖱️
-                    Upload ontology file:*""", type=ontology_format_list, key=st.session_state["key_ontology_uploader"])
+        if st.session_state["ontology_file"]:
 
-            if st.session_state["ontology_file"]:
+            g_candidate, fmt_candidate = utils.parse_ontology(st.session_state["ontology_file"])
+            st.session_state["g_ontology_from_file_candidate"] = g_candidate
+            st.session_state["g_ontology_from_file_candidate_fmt"] = fmt_candidate
+            st.session_state["g_ontology_from_file_candidate_label"] = utils.get_ontology_human_readable_name(st.session_state["g_ontology_from_file_candidate"], source_file=st.session_state["ontology_file"])
 
-                g_candidate, fmt_candidate = utils.parse_ontology(st.session_state["ontology_file"])
-                st.session_state["g_ontology_from_file_candidate"] = g_candidate
-                st.session_state["g_ontology_from_file_candidate_fmt"] = fmt_candidate
-                st.session_state["g_ontology_from_file_candidate_label"] = utils.get_ontology_human_readable_name(st.session_state["g_ontology_from_file_candidate"], source_file=st.session_state["ontology_file"])
 
-                if not utils.is_valid_ontology(g_candidate):
-                    with col1b:
-                        st.markdown(f"""<div class="error-message">
-                            ❌ File <b>does not</b> contain a valid ontology.
+            if not utils.is_valid_ontology(g_candidate):
+                with col1b:
+                    st.markdown(f"""<div class="error-message">
+                        ❌ File <b>does not</b> contain a valid ontology.
+                    </div>""", unsafe_allow_html=True)
+                    st.write("")
+
+            else:
+                with col1b:
+                    st.markdown(f"""<div class="success-message">
+                            ✔️ <b>Valid ontology:</b> <b style="color:#F63366;">
+                            {st.session_state["g_ontology_from_file_candidate_label"]}</b>
+                            <small>(parsed successfully with format
+                            <b>{st.session_state["g_ontology_from_file_candidate_fmt"]}</b>).</small>
                         </div>""", unsafe_allow_html=True)
 
-                elif st.session_state["g_ontology_from_file_candidate_label"] in st.session_state["g_ontology_components_dict"]:
-                    with col1b:
+            if not st.session_state["g_ontology"]:   #no ontology imported yet
+                with col1a:
+                    st.button("Add", key="key_load_ontology_from_file_button", on_click=load_ontology_from_file)
+
+            else:   # an ontology is already imported
+
+                if st.session_state["g_ontology_from_file_candidate_label"] in st.session_state["g_ontology_components_dict"]:
+                    with col1a:
                         st.markdown(f"""<div class="error-message">
                                 ❌ The ontology <b>
                                 {st.session_state["g_ontology_from_file_candidate_label"]}</b>
@@ -392,13 +325,6 @@ with tab1:
                 else:
                     with col1a:
                         st.button("Add", key="key_extend_ontology_from_file_button", on_click=extend_ontology_from_file)
-                    with col1b:
-                        st.markdown(f"""<div class="success-message">
-                                ✔️ <b>Valid ontology:</b> <b style="color:#F63366;">
-                                {st.session_state["g_ontology_from_file_candidate_label"]}</b><br>
-                                <small>(parsed successfully with format
-                                <b>{st.session_state["g_ontology_from_file_candidate_fmt"]}</b>).</small>
-                            </div>""", unsafe_allow_html=True)
 
                     if utils.check_ontology_overlap(st.session_state["g_ontology_from_file_candidate"], st.session_state["g_ontology"]):
                         with col1b:
@@ -408,12 +334,11 @@ with tab1:
                                 </div>""", unsafe_allow_html=True)
                             st.write("")
 
-        with col1:
-            st.write("________")
 
     #DISCARD ONTOLOGY___________________________________
     if st.session_state["g_ontology"]:   #ontology loaded and more than 1 component
         with col1:
+            st.write("________")
             st.markdown("""<div class="purple-heading">
                     🗑️ Remove Ontology
                 </div>""", unsafe_allow_html=True)

--- a/pages/21_📊_SQL_Databases.py
+++ b/pages/21_📊_SQL_Databases.py
@@ -184,9 +184,9 @@ with tab1:
                     st.write("")
                     st.dataframe(db_connections_df, hide_index=True)
 
-    # SUCCESS MESSAGE: UPDATE CONN STATUS---------------------------------------
+    # SUCCESS MESSAGE: UPDATE CONNECTION STATUS---------------------------------
     if st.session_state["db_connection_status_updated_ok_flag"]:
-        with col1a:
+        with col2b:
             st.markdown(f"""<div class="success-message-flag">
                 ✅ The <b>database connection status</b> has been updated!
             </div>""", unsafe_allow_html=True)

--- a/pages/21_📊_SQL_Databases.py
+++ b/pages/21_📊_SQL_Databases.py
@@ -130,13 +130,24 @@ with tab1:
         st.write("")
         st.write("")
 
-        rows = [{"Label": label, "Engine": st.session_state["db_connections_dict"][label][0],
-                "Database": st.session_state["db_connections_dict"][label][3],
-                "Status": st.session_state["db_connection_status_dict"][label][0]}
-                for label in reversed(list(st.session_state["db_connections_dict"].keys()))]
-        db_connections_df = pd.DataFrame(rows)
-        last_added_db_connections_df = db_connections_df.head(utils.get_max_length_for_display()[1])
+    # SUCCESS MESSAGE: UPDATE CONNECTION STATUS---------------------------------
+    if st.session_state["db_connection_status_updated_ok_flag"]:
+        with col2b:
+            st.markdown(f"""<div class="success-message-flag">
+                ✅ The <b>database connection status</b> has been updated!
+            </div>""", unsafe_allow_html=True)
+        st.session_state["db_connection_status_updated_ok_flag"] = False
+        time.sleep(utils.get_success_message_time())
+        st.rerun()
 
+    rows = [{"Label": label, "Engine": st.session_state["db_connections_dict"][label][0],
+            "Database": st.session_state["db_connections_dict"][label][3],
+            "Status": st.session_state["db_connection_status_dict"][label][0]}
+            for label in reversed(list(st.session_state["db_connections_dict"].keys()))]
+    db_connections_df = pd.DataFrame(rows)
+    last_added_db_connections_df = db_connections_df.head(utils.get_max_length_for_display()[1])
+
+    with col2b:
         max_length = utils.get_max_length_for_display()[1]   # max number of connections to show directly
         if st.session_state["db_connections_dict"]:
             if len(st.session_state["db_connections_dict"]) < max_length:
@@ -154,27 +165,27 @@ with tab1:
                     </div>""", unsafe_allow_html=True)
             st.dataframe(last_added_db_connections_df, hide_index=True)
 
-            with col2:
-                col2a, col2b, col2c = st.columns([0.5,0.8,1.2])
-            with col2c:
-                if "dark_mode_flag" not in st.session_state or not st.session_state["dark_mode_flag"]:
-                    highlight_color = "#fff7db"
-                else:
-                    highlight_color = "#7a6228"
-                st.markdown(f"""<div style='text-align: right; font-size: 11px; margin-top: -15px;'>
-                    <span style='background-color: {highlight_color}; padding: 2px 6px; border-radius: 4px;'>🕹️ must be manually updated</span>
+        with col2:
+            col2a, col2b, col2c = st.columns([0.5,0.8,1.2])
+        with col2c:
+            if "dark_mode_flag" not in st.session_state or not st.session_state["dark_mode_flag"]:
+                highlight_color = "#fff7db"
+            else:
+                highlight_color = "#7a6228"
+            st.markdown(f"""<div style='text-align: right; font-size: 11px; margin-top: -15px;'>
+                <span style='background-color: {highlight_color}; padding: 2px 6px; border-radius: 4px;'>🕹️ must be manually updated</span>
+            </div>""", unsafe_allow_html=True)
+
+        with col2b:
+            st.button("Update", key="key_update_db_connections_button", on_click=update_db_connections)
+
+        with col2:
+            col2a, col2b = st.columns([0.5,2])
+        with col2b:
+            st.write("")
+            st.markdown("""<div class="info-message-gray">
+            🐢 This pannel can be <b>slow</b> <small>if there are failed connections</small>.
                 </div>""", unsafe_allow_html=True)
-
-            with col2b:
-                st.button("Update", key="key_update_db_connections_button", on_click=update_db_connections)
-
-            with col2:
-                col2a, col2b = st.columns([0.5,2])
-            with col2b:
-                st.write("")
-                st.markdown("""<div class="info-message-gray">
-                🐢 This pannel can be <b>slow</b> <small>if there are failed connections</small>.
-                    </div>""", unsafe_allow_html=True)
 
         # Option to show all connections (if too many)
         with col2b:
@@ -183,16 +194,6 @@ with tab1:
                 with st.expander("🔎 Show all connections"):
                     st.write("")
                     st.dataframe(db_connections_df, hide_index=True)
-
-    # SUCCESS MESSAGE: UPDATE CONNECTION STATUS---------------------------------
-    if st.session_state["db_connection_status_updated_ok_flag"]:
-        with col2b:
-            st.markdown(f"""<div class="success-message-flag">
-                ✅ The <b>database connection status</b> has been updated!
-            </div>""", unsafe_allow_html=True)
-        st.session_state["db_connection_status_updated_ok_flag"] = False
-        time.sleep(utils.get_success_message_time())
-        st.rerun()
 
     # PURPLE HEADER: ADD NEW CONNECTION-----------------------------------------
     with col1:

--- a/pages/24_🔍_Explore_Mapping.py
+++ b/pages/24_🔍_Explore_Mapping.py
@@ -1240,12 +1240,19 @@ with tab4:
     list_to_choose.remove("jsonld")
 
     with col1a:
-        format_options_dict = {"🐢 turtle": "turtle", "3️⃣ ntriples": "nt",
-            "📐 trig": "trig"}
+        format_options_dict = {"🐢 turtle": "turtle", "3️⃣ ntriples": "nt"}
         preview_format_display = st.radio("🖱️ Select format:*", format_options_dict,
             horizontal=True, label_visibility="collapsed", key="key_export_format_selectbox")
         preview_format = format_options_dict[preview_format_display]
 
     if preview_format != "Select format":
         serialised_data = st.session_state["g_mapping"].serialize(format=preview_format)
-        st.code(serialised_data)
+        max_length = utils.get_max_length_for_display()[9]
+        if len(serialised_data) > max_length:
+            with col1:
+                st.markdown(f"""<div class="info-message-blue">
+                    🐘 <b>Your mapping is quite large</b> ({utils.format_number_for_display(len(st.session_state["g_mapping"]))} triples).
+                    <small>Showing only the first {utils.format_number_for_display(max_length)} characters
+                    (out of {utils.format_number_for_display(len(serialised_data))}) to avoid performance issues.</small>
+                </div>""", unsafe_allow_html=True)
+        st.code(serialised_data[:max_length])

--- a/pages/25_🔬_Ontology-Mapping_Lens.py
+++ b/pages/25_🔬_Ontology-Mapping_Lens.py
@@ -77,7 +77,7 @@ with tab1:
         if class_flag or property_flag:
             with col2b:
                 st.markdown(f"""<div class="info-message-gray">
-                        🧮 Composition calculated with the number of rules which use the class or property.
+                        🧮 Composition calculated with the <b>number of rules</b> which use the class or property.
                     </div>""", unsafe_allow_html=True)
 
 #________________________________________________

--- a/utils.py
+++ b/utils.py
@@ -645,6 +645,7 @@ def init_session_state_variables():
         st.session_state["original_g_size_cache"] = 0
         st.session_state["original_g_mapping_ns_dict"] = {}
         st.session_state["cached_mapping_retrieved_ok_flag"] = False
+        st.session_state["everything_reseted_ok_flag"] = False
         st.session_state["g_label_changed_ok_flag"] = False
         st.session_state["candidate_g_mapping"] = Graph()
         # TAB2

--- a/utils.py
+++ b/utils.py
@@ -562,7 +562,7 @@ def format_number_for_display(number):
 
     # >10 M  eg. 21M
     if number >= 10*10**6:
-        number_for_display = f"{round(int(number)/ 10**6)}M"
+        number_for_display = f"{int(number/ 10**6)}M"
 
     # 1-10 M  eg. 3.4M
     elif number >= 10**6:
@@ -574,7 +574,7 @@ def format_number_for_display(number):
 
     # 1k-10k  eg. 2.9k
     elif number >= 10**3:
-        number_for_display = f"{int(number / 1000)}k"
+        number_for_display = f"{round(number / 1000, 1)}k"
 
     # 10-1k  eg. 545
     elif number >= 10:
@@ -614,11 +614,11 @@ def format_number_for_display(number):
 # 4. List of multiselect items for hard display     # 5 Long lists for soft display
 # 6. Label in network visualisation (characters)
 # 7. Suggested mapping label (characters)    8. URL for display (characters)
-# 9. Max number of triples for ontology to be considered large
+# 9. Max characters when displaying ontology/mapping serialisation (ttl or nt)
 # 10. Query for display
 def get_max_length_for_display():
 
-    return [50, 10, 100, 20, 5, 5, 20, 15, 40, 10000, 30]
+    return [50, 10, 100, 20, 5, 5, 20, 15, 40, 100000, 30]
 #_______________________________________________________
 
 

--- a/utils.py
+++ b/utils.py
@@ -1726,33 +1726,36 @@ def get_candidate_ontology_info_messages(g, g_label):
         already_bound_ns_list = []
 
         for pr, ns in ontology_ns_dict.items():
-            if ns in mapping_ns_dict.values() and (pr not in mapping_ns_dict or mapping_ns_dict[pr] != ns):
+            if ns in mapping_ns_dict.values() and (pr not in mapping_ns_dict or str(mapping_ns_dict[pr]) != str(ns)):
                 already_bound_ns_list.append(ns)
-            elif pr in mapping_ns_dict and str(ns) != mapping_ns_dict[pr]:
+            elif pr in mapping_ns_dict and str(ns) != str(mapping_ns_dict[pr]):
                 already_used_prefix_list.append(pr)
 
-        if already_used_prefix_list and already_bound_ns_list:
-            warning_html += f"""⚠️ <small><b>Prefixes already in use ({len(already_used_prefix_list)})</b>
-                    will be auto-renamed.
-                    <b>Already bound namespaces ({len(already_bound_ns_list)})</b>
-                    will be ignored.</small>"""
-        elif already_used_prefix_list:
-            warning_html += f"""⚠️ <b>Prefixes already in use ({len(already_used_prefix_list)})</b>
-                    <small>will be auto-renamed.</small><br>"""
-        elif already_bound_ns_list:
-            warning_html += f"""<b>Already bound namespaces ({len(already_bound_ns_list)})</b>
-                    <small> will be ignored.</small></div>"""
+        # if already_used_prefix_list and already_bound_ns_list:
+        #     warning_html += f"""⚠️ <small><b>Prefixes already in use ({len(already_used_prefix_list)})</b>
+        #             will be auto-renamed.
+        #             <b>Already bound namespaces ({len(already_bound_ns_list)})</b>
+        #             will be ignored.</small><br>"""
+        # elif already_used_prefix_list:
+        #     warning_html += f"""⚠️ <b>Prefixes already in use ({len(already_used_prefix_list)})</b>
+        #             <small>will be auto-renamed.</small><br>"""
+        # elif already_bound_ns_list:
+        #     warning_html += f"""⚠️ <b>Already bound namespaces ({len(already_bound_ns_list)})</b>
+        #             <small> will be ignored.</small><br>"""
 
         if utils.check_ontology_overlap(g, st.session_state["g_ontology"]):
             warning_html += f"""⚠️ <b>Ontologies overlap</b>. <small>Check them
-                        externally to make sure they are aligned and compatible.</small></div>"""
+                        externally to make sure they are aligned and compatible.</small><br>"""
 
+        if already_used_prefix_list or already_bound_ns_list:
+            warning_html += f"""⚠️ <b>Duplicated namespaces</b> <small>handled automatically.</small>"""
         # success message
         success_html += f"""✔️ <b>Valid ontology:</b> <b style="color:#F63366;">
                 {st.session_state["g_ontology_from_link_candidate_label"]}</b>
                 <small>(parsed successfully with format
                 <b>{st.session_state["g_ontology_from_link_candidate_fmt"]}</b>).</small>"""
 
+    st.write("HERE", already_used_prefix_list, already_bound_ns_list)
 
     return [valid_ontology_flag, success_html, warning_html, error_html]
 

--- a/utils.py
+++ b/utils.py
@@ -1731,18 +1731,6 @@ def get_candidate_ontology_info_messages(g, g_label):
             elif pr in mapping_ns_dict and str(ns) != str(mapping_ns_dict[pr]):
                 already_used_prefix_list.append(pr)
 
-        # if already_used_prefix_list and already_bound_ns_list:
-        #     warning_html += f"""⚠️ <small><b>Prefixes already in use ({len(already_used_prefix_list)})</b>
-        #             will be auto-renamed.
-        #             <b>Already bound namespaces ({len(already_bound_ns_list)})</b>
-        #             will be ignored.</small><br>"""
-        # elif already_used_prefix_list:
-        #     warning_html += f"""⚠️ <b>Prefixes already in use ({len(already_used_prefix_list)})</b>
-        #             <small>will be auto-renamed.</small><br>"""
-        # elif already_bound_ns_list:
-        #     warning_html += f"""⚠️ <b>Already bound namespaces ({len(already_bound_ns_list)})</b>
-        #             <small> will be ignored.</small><br>"""
-
         if utils.check_ontology_overlap(g, st.session_state["g_ontology"]):
             warning_html += f"""⚠️ <b>Ontologies overlap</b>. <small>Check them
                         externally to make sure they are aligned and compatible.</small><br>"""
@@ -1754,8 +1742,6 @@ def get_candidate_ontology_info_messages(g, g_label):
                 {st.session_state["g_ontology_from_link_candidate_label"]}</b>
                 <small>(parsed successfully with format
                 <b>{st.session_state["g_ontology_from_link_candidate_fmt"]}</b>).</small>"""
-
-    st.write("HERE", already_used_prefix_list, already_bound_ns_list)
 
     return [valid_ontology_flag, success_html, warning_html, error_html]
 


### PR DESCRIPTION
Improved Ontologies page:
- Grouped import and extend ontology
- Moved get_candidate_ontology_info_messages to utils
- Fixed info messages for file ontologies
- Fixed duplicated namespaces detection and warning

Small changes:
- Organised comments in Global Configuration
- Moved success messages to right column for right column actions
- Removed trig option for displaying ontologies and mapping
- Limited characters for mapping preview