### PR TITLE
Display references/datatypes/language tags with {} ^^ and @ and debugged predicate in pom

### DIFF
--- a/pages/23_🏗️_Build_Mapping.py
+++ b/pages/23_🏗️_Build_Mapping.py
@@ -1771,7 +1771,7 @@ with tab3:
 
         with col1a:
             if st.session_state["last_added_tm_list"]:
-                list_to_choose = list(reversed(tm_dict))
+                list_to_choose = sorted(tm_dict)
                 list_to_choose.insert(0, "Select a TriplesMap")
                 tm_label_for_pom = st.selectbox("🖱️ Select a TriplesMap:*", list_to_choose, key="key_tm_label_for_pom",
                     index=list_to_choose.index(st.session_state["last_added_tm_list"][0]))
@@ -2315,7 +2315,10 @@ with tab3:
                     <div style="font-size:13px; font-weight:500; margin-top:10px; margin-bottom:6px; border-top:0.5px solid #ccc; padding-bottom:4px;">
                         <b>🔍 Preview</b><br>
                     </div>""", unsafe_allow_html=True)
-                    utils.preview_rule(sm_rule, selected_p_for_display, om_iri_for_display)  # display rule
+                    if om_generation_rule == "Reference 📊":
+                        utils.preview_rule(sm_rule, selected_p_for_display, om_iri_for_display, is_reference=True)  # display rule
+                    else:
+                        utils.preview_rule(sm_rule, selected_p_for_display, om_iri_for_display)  # display rule
 
     with col2b:
         st.markdown("""<div class='info-message-gray'>

--- a/pages/23_🏗️_Build_Mapping.py
+++ b/pages/23_🏗️_Build_Mapping.py
@@ -2315,10 +2315,21 @@ with tab3:
                     <div style="font-size:13px; font-weight:500; margin-top:10px; margin-bottom:6px; border-top:0.5px solid #ccc; padding-bottom:4px;">
                         <b>🔍 Preview</b><br>
                     </div>""", unsafe_allow_html=True)
-                    if om_generation_rule == "Reference 📊":
-                        utils.preview_rule(sm_rule, selected_p_for_display, om_iri_for_display, is_reference=True)  # display rule
-                    else:
-                        utils.preview_rule(sm_rule, selected_p_for_display, om_iri_for_display)  # display rule
+
+                datatype_iri = False
+                language_tag = False
+                if om_datatype != "Select datatype" and om_datatype != "Natural language tag":
+                    datatype_dict = utils.get_datatypes_dict()
+                    datatype_iri = datatype_dict[om_datatype]
+                elif om_datatype == "Natural language tag":
+                    language_tag = Literal(om_language_tag)
+
+                existing_datatype = om_datatype if om_generation_rule == "Reference 📊" else False
+                is_reference = True if om_generation_rule == "Reference 📊" else False
+                with col1a:
+                    utils.preview_rule(sm_rule, selected_p_for_display, om_iri_for_display, is_reference=is_reference,
+                        datatype=datatype_iri, language_tag=language_tag)  # display rule
+
 
     with col2b:
         st.markdown("""<div class='info-message-gray'>

--- a/pages/24_🔍_Explore_Mapping.py
+++ b/pages/24_🔍_Explore_Mapping.py
@@ -281,10 +281,28 @@ with tab2:
                 predicate = row.predicate if hasattr(row, "predicate") and row.predicate else ""
                 object_ = row.object_value if hasattr(row, "object_value") and row.object_value else ""
 
-                if (None, RML.reference, Literal(subject)) in st.session_state["g_mapping"]:  # reference
+                # Add {} to references
+                if (None, RML.reference, Literal(subject)) in st.session_state["g_mapping"]:
                     subject = "{" + f"""{subject}"""  + "}"
-                if (None, RML.reference, Literal(object_)) in st.session_state["g_mapping"]:  # reference
+                if (None, RML.reference, Literal(object_)) in st.session_state["g_mapping"]:
                     object_ = "{" + f"""{object_}"""  + "}"
+
+                # Add datatype/language tag to object
+                datatype = ""
+                language_tag = ""
+                for s, p, o in st.session_state["g_mapping"].triples((om, RML.datatype, None)):
+                    datatype = o
+                    break
+                for s, p, o in st.session_state["g_mapping"].triples((om, RML.language, None)):
+                    language_tag = o
+                    break
+                # if datatype:
+                #     object_w_datatype = object_ + "^^" + datatype
+                #     for k, v in utils.get_datatypes_dict().items():
+                #         if str(datatype) == str(v):
+                #             object_w_datatype = object_  + "^^" + k
+                #             break
+                #     object_ = object_w_datatype
 
                 # Optional: apply label formatting
                 tm_label = utils.get_node_label(tm)
@@ -295,6 +313,8 @@ with tab2:
                         "Subject": utils.format_iri_to_prefix_label(subject),
                         "Predicate": utils.format_iri_to_prefix_label(predicate),
                         "Object": utils.format_iri_to_prefix_label(object_),
+                        "Datatype": utils.format_iri_to_prefix_label(datatype),
+                        "Language tag": language_tag,
                         "TriplesMap": utils.format_iri_to_prefix_label(tm),
                         "Subject Map": utils.format_iri_to_prefix_label(sm),
                         "Predicate-Object Map": utils.format_iri_to_prefix_label(pom),

--- a/pages/24_🔍_Explore_Mapping.py
+++ b/pages/24_🔍_Explore_Mapping.py
@@ -281,6 +281,11 @@ with tab2:
                 predicate = row.predicate if hasattr(row, "predicate") and row.predicate else ""
                 object_ = row.object_value if hasattr(row, "object_value") and row.object_value else ""
 
+                if (None, RML.reference, Literal(subject)) in st.session_state["g_mapping"]:  # reference
+                    subject = "{" + f"""{subject}"""  + "}"
+                if (None, RML.reference, Literal(object_)) in st.session_state["g_mapping"]:  # reference
+                    object_ = "{" + f"""{object_}"""  + "}"
+
                 # Optional: apply label formatting
                 tm_label = utils.get_node_label(tm)
 

--- a/utils.py
+++ b/utils.py
@@ -1084,7 +1084,7 @@ def change_g_mapping_base_ns(prefix, namespace):
 # Function to get the default base iri for the base components
 def get_default_base_ns():
 
-    return ["map3x", URIRef("http://3xmap.org/mapping/")]
+    return ["map3x", Namespace("http://3xmap.org/mapping/")]
 #_____________________________________________________
 
 #_____________________________________________________
@@ -2749,7 +2749,7 @@ def is_valid_url_mapping(mapping_url, show_info):
 
 #________________________________________________
 # Function to display a rule
-def preview_rule(s_for_display, p_for_display, o_for_display):
+def preview_rule(s_for_display, p_for_display, o_for_display, is_reference=False):
 
     inner_html = ""
     max_length = 40
@@ -2758,9 +2758,15 @@ def preview_rule(s_for_display, p_for_display, o_for_display):
     p_for_display = "" if not p_for_display else p_for_display
     o_for_display = "" if not o_for_display else o_for_display
 
-    formatted_s = f"""{s_for_display}""" if len(s_for_display) < max_length else "<small>" + f"""{s_for_display}""" + "</small>"
+    if (None, RML.reference, Literal(s_for_display)) in st.session_state["g_mapping"]:  # reference
+        formatted_s = "{" + f"""{s_for_display}"""  + "}" if len(s_for_display) < max_length else "<small>{" + f"""{s_for_display}""" + "}</small>"
+    else:
+        formatted_s = f"""{s_for_display}""" if len(s_for_display) < max_length else "<small>" + f"""{s_for_display}""" + "</small>"
     formatted_p = f"""{p_for_display}""" if len(p_for_display) < max_length else "<small>" + f"""{p_for_display}""" + "</small>"
-    formatted_o = f"""{o_for_display}""" if len(o_for_display) < max_length else "<small>" + f"""{o_for_display}""" + "</small>"
+    if is_reference:
+        formatted_o = "{" + f"""{o_for_display}""" + "}" if len(o_for_display) < max_length else "<small>{" + f"""{o_for_display}""" + "}</small>"
+    else:
+        formatted_o = f"""{o_for_display}""" if len(o_for_display) < max_length else "<small>" + f"""{o_for_display}""" + "</small>"
 
     st.markdown(f"""<div class="blue-preview-message" style="margin-top:0px; padding-top:4px;">
         <small><b style="color:#F63366; font-size:10px; margin-top:0px;">🏷️ Subject → 🔗 Predicate → 🎯 Object</b></small>
@@ -2793,9 +2799,15 @@ def preview_rule_list(s_for_display, p_for_display, o_for_display):
     p_for_display = "" if not p_for_display else p_for_display
     o_for_display = "" if not o_for_display else o_for_display
 
-    formatted_s = f"""{s_for_display}""" if len(s_for_display) < max_length else "<small>" + f"""{s_for_display}""" + "</small>"
+    if (None, RML.reference, Literal(s_for_display)) in st.session_state["g_mapping"]:  # reference
+        formatted_s = "{" + f"""{s_for_display}"""  + "}" if len(s_for_display) < max_length else "<small>{" + f"""{s_for_display}""" + "}</small>"
+    else:
+        formatted_s = f"""{s_for_display}""" if len(s_for_display) < max_length else "<small>" + f"""{s_for_display}""" + "</small>"
     formatted_p = f"""{p_for_display}""" if len(p_for_display) < max_length else "<small>" + f"""{p_for_display}""" + "</small>"
-    formatted_o = f"""{o_for_display}""" if len(o_for_display) < max_length else "<small>" + f"""{o_for_display}""" + "</small>"
+    if (None, RML.reference, Literal(o_for_display)) in st.session_state["g_mapping"]:  # reference
+        formatted_o = "{" + f"""{o_for_display}""" + "}" if len(o_for_display) < max_length else "<small>{" + f"""{o_for_display}""" + "}</small>"
+    else:
+        formatted_o = f"""{o_for_display}""" if len(o_for_display) < max_length else "<small>" + f"""{o_for_display}""" + "</small>"
 
     inner_html += f"""<div style="display:flex; justify-content:space-between; align-items:center; gap:10px; margin-top:0px;">
             <div style="flex:1; min-width:120px; text-align:center; border:0.5px solid black; padding:5px; border-radius:5px; word-break:break-word;">


### PR DESCRIPTION
- Debugged predicate addition in pom and allowed to not use namespace for predicate if valid iri
- References displayed between {}
- Datatype and language tag shown with ^^ and @ when object rule displayed